### PR TITLE
ループずらし機能

### DIFF
--- a/app.html
+++ b/app.html
@@ -70,8 +70,8 @@
       Source Code and Doc(Japanese) are <a href="https://github.com/hmoriz/midi-wave-converter">here</a><BR>
       MIDI -> Wave only version is <a href="/index.html">here</a>
     </p>
-    <p id="wavearea">&#x30FB;Wave -> OGG&nbsp;</p>
-    <p id="midiarea">&#x30FB;MIDI -> Wave -> OGG&nbsp;</p>
+    <p id="wavearea">&#x30FB;Wave -> OGG<BR/></p>
+    <p id="midiarea">&#x30FB;MIDI -> Wave -> OGG<BR/></p>
     <div id="loading"></div>
     <p id="inputarea">&#x30FB;Settings for MIDI -> OGG&nbsp;</p>
     <p id="audioarea">Wave...<BR/></p>

--- a/app.js
+++ b/app.js
@@ -5160,7 +5160,7 @@ select.id = "byteRate";
 [0.1, 0.25, 0.5, 1, 1.5, 2].forEach((num) => {
     const byteRate = num * 44100;
     const option = document.createElement('option');
-    option.value = byteRate.toString()
+    option.value = byteRate.toString();
     option.text = `${byteRate} Hz`;
     select.appendChild(option);
     if (byteRate === 44100) {

--- a/app.js
+++ b/app.js
@@ -5139,14 +5139,14 @@ inputMIDI.onchange = async (e) => {
 }
 
 const div4 = document.createElement('div');
-div4.appendChild(document.createTextNode("output by channel"));
+div4.appendChild(document.createTextNode("- output by channel"));
 const input4 = document.createElement('input');
 input4.id = "outputChannelCheck";
 input4.type = "checkbox";
 div4.appendChild(input4);
 document.getElementById('inputarea').appendChild(div4);
 const div5 = document.createElement('div');
-div5.appendChild(document.createTextNode("enable effect"));
+div5.appendChild(document.createTextNode("- enable effect"));
 const input5 = document.createElement('input');
 input5.id = "withEffect";
 input5.type = "checkbox";
@@ -5154,7 +5154,7 @@ input5.checked = true;
 div5.appendChild(input5);
 document.getElementById('inputarea').appendChild(div5);
 const div6 = document.createElement('div');
-div6.appendChild(document.createTextNode("sample rate"));
+div6.appendChild(document.createTextNode("- sample rate"));
 const select = document.createElement('select');
 select.id = "byteRate";
 [0.1, 0.25, 0.5, 1, 1.5, 2].forEach((num) => {
@@ -5169,3 +5169,10 @@ select.id = "byteRate";
 });
 div6.appendChild(select);
 document.getElementById('inputarea').appendChild(div6);
+const div7 = document.createElement('div');
+div7.appendChild(document.createTextNode("- adjust loop offset"));
+const input7 = document.createElement('input');
+input7.id = "adjustLoop";
+input7.type = "checkbox";
+div7.appendChild(input7);
+document.getElementById('inputarea').appendChild(div7);

--- a/app.js
+++ b/app.js
@@ -5025,15 +5025,19 @@ run();
 
 const inputWave = document.createElement('input');
 inputWave.type = 'file';
-document.getElementById('wavearea').append(inputWave);
+document.getElementById('wavearea').appendChild(document.createTextNode("wave file: "));
+document.getElementById('wavearea').appendChild(inputWave);
+
+const subProcessSegmentSize = 16384;
 
 function waveToOGG(/**@type {Uint8Array}*/array, /**@type {(value:any)=>void}*/ done, loopStart, loopLength) {
-    const segments = Math.ceil(array.byteLength / 16384);
+    const segments = Math.ceil(array.byteLength / subProcessSegmentSize);
     const segmentDiversion = 100;
     const pieceSegments = Math.trunc(segments / segmentDiversion);
     const lastSegments = segments % segmentDiversion;
+    // sample rate from wave
     const sampleRate = array[24] + (array[25] << 8) + (array[26] << 16) + (array[27] << 24);
-    console.log(segments, pieceSegments, lastSegments, loopStart, loopLength);
+    // console.log(segments, pieceSegments, lastSegments, loopStart, loopLength);
     const subProcess = (j) => {
         for (let i = 0; i < ((j === pieceSegments) ? lastSegments : segmentDiversion); i++) {
             const array1 = Uint8Array.from(array.slice((j * segmentDiversion + i) * 16384, (j * segmentDiversion + i + 1) * 16384));
@@ -5109,6 +5113,7 @@ const main = require('./index.ts');
 const midiElement = document.getElementById('midiarea');
 const inputDLS = document.createElement('input');
 inputDLS.type = 'file';
+midiElement.appendChild(document.createTextNode("gm.dls: "));
 midiElement.appendChild(inputDLS);
 
 let dlsResult;
@@ -5118,6 +5123,7 @@ inputDLS.onchange = async (e) => {
 
 const inputMIDI = document.createElement('input');
 inputMIDI.type = 'file';
+midiElement.appendChild(document.createTextNode("midi file: "));
 midiElement.appendChild(inputMIDI);
 
 inputMIDI.onchange = async (e) => {

--- a/building/post.js
+++ b/building/post.js
@@ -135,7 +135,7 @@ select.id = "byteRate";
 [0.1, 0.25, 0.5, 1, 1.5, 2].forEach((num) => {
     const byteRate = num * 44100;
     const option = document.createElement('option');
-    option.value = byteRate.toString()
+    option.value = byteRate.toString();
     option.text = `${byteRate} Hz`;
     select.appendChild(option);
     if (byteRate === 44100) {

--- a/building/post.js
+++ b/building/post.js
@@ -114,14 +114,14 @@ inputMIDI.onchange = async (e) => {
 }
 
 const div4 = document.createElement('div');
-div4.appendChild(document.createTextNode("output by channel"));
+div4.appendChild(document.createTextNode("- output by channel"));
 const input4 = document.createElement('input');
 input4.id = "outputChannelCheck";
 input4.type = "checkbox";
 div4.appendChild(input4);
 document.getElementById('inputarea').appendChild(div4);
 const div5 = document.createElement('div');
-div5.appendChild(document.createTextNode("enable effect"));
+div5.appendChild(document.createTextNode("- enable effect"));
 const input5 = document.createElement('input');
 input5.id = "withEffect";
 input5.type = "checkbox";
@@ -129,7 +129,7 @@ input5.checked = true;
 div5.appendChild(input5);
 document.getElementById('inputarea').appendChild(div5);
 const div6 = document.createElement('div');
-div6.appendChild(document.createTextNode("sample rate"));
+div6.appendChild(document.createTextNode("- sample rate"));
 const select = document.createElement('select');
 select.id = "byteRate";
 [0.1, 0.25, 0.5, 1, 1.5, 2].forEach((num) => {
@@ -144,3 +144,10 @@ select.id = "byteRate";
 });
 div6.appendChild(select);
 document.getElementById('inputarea').appendChild(div6);
+const div7 = document.createElement('div');
+div7.appendChild(document.createTextNode("- adjust loop offset"));
+const input7 = document.createElement('input');
+input7.id = "adjustLoop";
+input7.type = "checkbox";
+div7.appendChild(input7);
+document.getElementById('inputarea').appendChild(div7);

--- a/building/post.js
+++ b/building/post.js
@@ -1,14 +1,18 @@
 const inputWave = document.createElement('input');
 inputWave.type = 'file';
-document.getElementById('wavearea').append(inputWave);
+document.getElementById('wavearea').appendChild(document.createTextNode("wave file: "));
+document.getElementById('wavearea').appendChild(inputWave);
+
+const subProcessSegmentSize = 16384;
 
 function waveToOGG(/**@type {Uint8Array}*/array, /**@type {(value:any)=>void}*/ done, loopStart, loopLength) {
-    const segments = Math.ceil(array.byteLength / 16384);
+    const segments = Math.ceil(array.byteLength / subProcessSegmentSize);
     const segmentDiversion = 100;
     const pieceSegments = Math.trunc(segments / segmentDiversion);
     const lastSegments = segments % segmentDiversion;
+    // sample rate from wave
     const sampleRate = array[24] + (array[25] << 8) + (array[26] << 16) + (array[27] << 24);
-    console.log(segments, pieceSegments, lastSegments, loopStart, loopLength);
+    // console.log(segments, pieceSegments, lastSegments, loopStart, loopLength);
     const subProcess = (j) => {
         for (let i = 0; i < ((j === pieceSegments) ? lastSegments : segmentDiversion); i++) {
             const array1 = Uint8Array.from(array.slice((j * segmentDiversion + i) * 16384, (j * segmentDiversion + i + 1) * 16384));
@@ -84,6 +88,7 @@ const main = require('./index.ts');
 const midiElement = document.getElementById('midiarea');
 const inputDLS = document.createElement('input');
 inputDLS.type = 'file';
+midiElement.appendChild(document.createTextNode("gm.dls: "));
 midiElement.appendChild(inputDLS);
 
 let dlsResult;
@@ -93,6 +98,7 @@ inputDLS.onchange = async (e) => {
 
 const inputMIDI = document.createElement('input');
 inputMIDI.type = 'file';
+midiElement.appendChild(document.createTextNode("midi file: "));
 midiElement.appendChild(inputMIDI);
 
 inputMIDI.onchange = async (e) => {

--- a/building/shell.html
+++ b/building/shell.html
@@ -70,8 +70,8 @@
       Source Code and Doc(Japanese) are <a href="https://github.com/hmoriz/midi-wave-converter">here</a><BR>
       MIDI -> Wave only version is <a href="/index.html">here</a>
     </p>
-    <p id="wavearea">&#x30FB;Wave -> OGG&nbsp;</p>
-    <p id="midiarea">&#x30FB;MIDI -> Wave -> OGG&nbsp;</p>
+    <p id="wavearea">&#x30FB;Wave -> OGG<BR/></p>
+    <p id="midiarea">&#x30FB;MIDI -> Wave -> OGG<BR/></p>
     <div id="loading"></div>
     <p id="inputarea">&#x30FB;Settings for MIDI -> OGG&nbsp;</p>
     <p id="audioarea">Wave...<BR/></p>

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,6 @@ import { Synthesizer } from "./synthesizer";
 import Chart from 'chart.js';
 import { Sample } from "./sample";
 import { Util } from "./util";
-import { DLS } from "./chunk";
 
 let canvas : HTMLCanvasElement;
 let dlsParseResult : DLSParseResult;
@@ -98,12 +97,13 @@ export async function loadMIDIFile(e : Event, dlsParseResult : DLSParseResult, w
     const outputChannelData = (document.getElementById('outputChannelCheck') as HTMLInputElement)?.checked;
     const withEffect = (document.getElementById('withEffect') as HTMLInputElement)?.checked;
     const byteRate = (document.getElementById('byteRate') as HTMLSelectElement)?.selectedOptions?.[0]?.value || Synthesizer.defaultByteRate;
+    const adjustLoopOffset = (document.getElementById('adjustLoop') as HTMLInputElement)?.checked;
     for (let i = 0; i < (e.target as HTMLInputElement).files.length; i++) {
         const file : File = (e.target as HTMLInputElement).files[i];
         const parser = new MIDIParser();
         const parseResult = await parser.parseFile(file);
         console.log(parseResult, dlsParseResult);
-        return Synthesizer.synthesizeMIDI(parseResult, dlsParseResult, withEffect, outputChannelData, Number(byteRate), (text) => {
+        return Synthesizer.synthesizeMIDI(parseResult, dlsParseResult, withEffect, outputChannelData, adjustLoopOffset, Number(byteRate), (text) => {
             document.getElementById('loading').innerText = text;
         }).then((synthesizeResult) => {
 
@@ -123,7 +123,6 @@ export async function loadMIDIFile(e : Event, dlsParseResult : DLSParseResult, w
                 const newAudioWithEffect = document.createElement('audio');
                 newAudioWithEffect.src = urlWithEffect;
                 newAudioWithEffect.controls = true;
-                newAudioWithEffect.loop = true;
     
                 audioDiv.appendChild(document.createTextNode("    with Effect: "));
                 audioDiv.appendChild(newAudioWithEffect);
@@ -133,7 +132,6 @@ export async function loadMIDIFile(e : Event, dlsParseResult : DLSParseResult, w
                 const newAudioOnlyEffect = document.createElement('audio');
                 newAudioOnlyEffect.src = urlOnlyEffect;
                 newAudioOnlyEffect.controls = true;
-                newAudioOnlyEffect.loop = true;
                 
                 audioDiv.appendChild(document.createTextNode("    only Effect: "));
                 audioDiv.appendChild(newAudioOnlyEffect);
@@ -237,6 +235,13 @@ function main() {
     });
     div5.appendChild(select);
     document.getElementById('inputarea').appendChild(div5);
+    const div6 = document.createElement('div');
+    div6.appendChild(document.createTextNode("・ ループ補正を有効にする"));
+    const input6 = document.createElement('input');
+    input6.id = "adjustLoop";
+    input6.type = "checkbox";
+    div6.appendChild(input6);
+    document.getElementById('inputarea').appendChild(div6);
 
     canvas = document.createElement('canvas');
     canvas.width = 1080;

--- a/index.ts
+++ b/index.ts
@@ -150,8 +150,8 @@ export async function loadMIDIFile(e : Event, dlsParseResult : DLSParseResult, w
                 const channelAudio = document.createElement('audio');
                 channelAudio.src = url;
                 channelAudio.controls = true;
-                div.appendChild(channelAudio)
-                document.getElementById("audioarea").appendChild(div);   
+                div.appendChild(channelAudio);
+                document.getElementById("audioarea").appendChild(div);
             });
             if (withChart) {
                 // 先頭のサンプルチャートを雑に作成
@@ -226,7 +226,7 @@ function main() {
     [0.1, 0.25, 0.5, 1, 1.5, 2].forEach((num) => {
         const byteRate = num * Synthesizer.defaultByteRate;
         const option = document.createElement('option');
-        option.value = byteRate.toString()
+        option.value = byteRate.toString();
         option.text = `${byteRate} Hz`;
         select.appendChild(option);
         if (byteRate === Synthesizer.defaultByteRate) {

--- a/synthesizer.ts
+++ b/synthesizer.ts
@@ -1108,9 +1108,9 @@ export namespace Synthesizer {
                                     loopAnnoyingNoteMap.get(channelID).push(attackingNoteData[0]);
                                 });
                                 // 現在のチャンネル情報を末尾に追加
-                                const currentChannelInfo = channelInfoMap.get(channelID)?.[0];
-                                if (currentChannelInfo) {
-                                    offsetChannelInfoMap.get(channelID).set(Math.ceil(maxOffset)-1, currentChannelInfo);
+                                const currentChannelInfos = channelInfoMap.get(channelID);
+                                if (currentChannelInfos && currentChannelInfos[0]) {
+                                    offsetChannelInfoMap.get(channelID).set(Math.ceil(maxOffset)-1, currentChannelInfos[0]);
                                 }
                             });
                             console.log("adjusting loop", offset, loopStartOffset, loopAnnoyingNoteMap);

--- a/synthesizer.ts
+++ b/synthesizer.ts
@@ -276,6 +276,7 @@ export namespace Synthesizer {
     }
 
     class NoteInfo {
+        offset            : number;
         noteID            : number;
         velocity          : number;
         endTick           : number;
@@ -330,11 +331,12 @@ export namespace Synthesizer {
     }
 
     export async function synthesizeMIDI(
-                midi : MidiParseInfo, 
-                dls : DLSParseInfo, 
-                withEffect: boolean = true, 
-                outputChannel : boolean = true, 
-                byteRate : number = defaultByteRate, 
+                midi : MidiParseInfo,
+                dls : DLSParseInfo,
+                withEffect: boolean = true,
+                outputChannel : boolean = true,
+                loopAdjusting : boolean = false,
+                byteRate : number = defaultByteRate,
                 onProcessCallback : (text : string) => void = null
             ) :  Promise<SynthesizeResult> {
 
@@ -598,6 +600,7 @@ export namespace Synthesizer {
             map.forEach((noteInfoArray, tick) => {
                 noteInfoArray.forEach(noteInfo => {
                     const offset = Math.trunc(tickToOffset.get(tick));
+                    noteInfo.offset = offset;
                     let endOffset : number;
                     if (noteInfo.endTick) {
                         endOffset = Math.trunc(tickToOffset.get(noteInfo.endTick));
@@ -635,13 +638,21 @@ export namespace Synthesizer {
         // channelID -> [waveDataR(Int16Array), waveDataL(Int16Array)]
         const channelWaveDatas = new Map<number, [Array<number>, Array<number>]>();
 
-        // channelID -> Array[attacked offset, valocity, sample_offset_speed_gain, last_sample_offset]
-        const channelIDAttackingNoteMap = new Map<number, Array<[number, NoteInfo, number, number]>>();
-        // channelID -> [ChannelInfo, wave, art1Info(for ins), lart(for ins)]
-        const channelInfoMap = new Map<number, [ChannelInfo, InstrumentData, Art1Info, DLS.LartChunk]>();
+        // channelID -> Array[NoteInfo, sample_offset_speed_gain, last_sample_offset]
+        const channelIDAttackingNoteMap = new Map<number, Array<[NoteInfo, number, number]>>();
+        // channelID -> [ChannelInfo, wave]
+        const channelInfoMap = new Map<number, [ChannelInfo, InstrumentData]>();
+
+        let loopStartOffset = -1;
+        let loopLength = -1;
+        let loopAdjustOffset = -1;
+        // channelID -> [NoteInfo]
+        const loopAnnoyingNoteMap = new Map<number, Array<NoteInfo>>();
+
         channelIDs.forEach(channelID => {
             channelIDAttackingNoteMap.set(channelID, new Array());
             channelWaveDatas.set(channelID, [new Array(), new Array()]);
+            loopAnnoyingNoteMap.set(channelID, new Array());
         });
         // channelID -> pitchBend(number)
         const pitchBendMap = new Map<number, number>();
@@ -663,13 +674,14 @@ export namespace Synthesizer {
 
         const processPartialMakeWaveSegment = (startOffset : number, endOffset : number) : Promise<void> => {
             return new Promise<void>((done) => {
+                let loopAdjustFlag = false;
                 const processPartialMakeWaveSegment2 = (startOffset: number, endOffset : number) => {
                     console.log("Synthesize Processing...", startOffset, "-", endOffset, "/", Math.ceil(maxOffset));
                     // TODO : 本当はこのファイルにdocumentを使うべきでない
                     onProcessCallback(`Synthesize Processing...${startOffset} / ${Math.ceil(maxOffset)}`);
 
                     const waveDataBufferForReverb : [number, number] = [0, 0]; // R L
-                    for (let offset = startOffset; offset < Math.min(endOffset, maxOffset); offset++) {
+                    for (let offset = startOffset; offset < Math.min(endOffset, Math.ceil(maxOffset)+ (loopAdjusting?(loopAdjustOffset-loopStartOffset):0)); offset++) {
                         waveDataR[offset] = 0;
                         waveDataL[offset] = 0;
                         const offsetForChorus = offset % waveDataBufferForChorusCapacity;
@@ -688,45 +700,69 @@ export namespace Synthesizer {
                         if (!outputChannel) {
                             offsetForChannelData = offset % 256;
                         }
+
+                        let tempLoopStart = -1;
                         
                         channelIDs.forEach((channelID) => {
                             channelWaveDatas.get(channelID)[0][offsetForChannelData] = 0;
                             channelWaveDatas.get(channelID)[1][offsetForChannelData] = 0;
                             // if (channelID !== 0) return; // 仮置
-                            const channelEvent = offsetChannelInfoMap.get(channelID)?.get(offset);
+                            let channelEvent = offsetChannelInfoMap.get(channelID)?.get(offset);
+                            if (offset >= maxOffset && loopAdjusting) {
+                                const adjustOffset = loopStartOffset + (offset - Math.ceil(maxOffset))-1;
+                                channelEvent = offsetChannelInfoMap.get(channelID)?.get(adjustOffset);
+                            }
                             if (channelEvent) {
                                 /** @ts-ignore  */
-                                const channelInfoData = dls.instrumentIDMap.get(channelEvent.instrumentID)?.get(channelID === 9 ? 2147483648 : channelEvent.bankID);
-                                const art1Info = getArt1InfoFromLarts(channelInfoData.insChunk.lart);
-                                channelInfoMap.set(channelID, [channelEvent, channelInfoData, art1Info, channelInfoData.insChunk.lart]);
+                                const instrumentData = dls.instrumentIDMap.get(channelEvent.instrumentID)?.get(channelID === 9 ? 2147483648 : channelEvent.bankID);
+                                channelInfoMap.set(channelID, [channelEvent, instrumentData]);
+                                if (offset < Math.ceil(maxOffset)-1 && channelEvent.loopStartTick >= 0) {
+                                    tempLoopStart = Math.round(tickToOffset.get(channelEvent.loopStartTick));
+                                    console.log(channelID, channelEvent.loopStartTick, tempLoopStart);
+                                }
                             }
                             const noteEvents = offsetNotesMap.get(channelID)?.get(offset);
                             if (noteEvents) {
                                 noteEvents.forEach(noteEvent => {
-                                    channelIDAttackingNoteMap.get(channelID).push([offset, noteEvent, 0, 0]);
+                                    channelIDAttackingNoteMap.get(channelID).push([noteEvent, 0, 0]);
                                 })
                             }
-                            const pitchBendEventMap = offsetPitchBendMap.get(channelID);
+                            if (offset >= maxOffset && loopAdjusting) {
+                                const adjustOffset = loopStartOffset + (offset - Math.ceil(maxOffset))-1;
+                                const addingNoteEvents = offsetNotesMap.get(channelID)?.get(adjustOffset);
+                                if (addingNoteEvents) {
+                                    addingNoteEvents.forEach(noteEvent => {
+                                        noteEvent.offset = offset;
+                                        noteEvent.endOffset = offset + noteEvent.length;
+                                        channelIDAttackingNoteMap.get(channelID).push([noteEvent, 0, 0]);
+                                    })
+                                }
+                            }
+                            let pitchBendEventMap = offsetPitchBendMap.get(channelID);
                             if (pitchBendEventMap && pitchBendEventMap.has(offset)) {
                                 const pitchBendEvent =  pitchBendEventMap.get(offset);
                                 pitchBendMap.set(channelID, pitchBendEvent);
+                            } else if (pitchBendEventMap && offset >= maxOffset && loopAdjusting) {
+                                const adjustOffset = loopStartOffset + (offset - Math.ceil(maxOffset))-1;
+                                if (pitchBendEventMap.has(adjustOffset)) {
+                                    const pitchBendEvent =  pitchBendEventMap.get(adjustOffset);
+                                    pitchBendMap.set(channelID, pitchBendEvent);
+                                }
                             }
-            
                             // 現在Onになっているノートに対してサンプルを収集しwaveDataに格納してく
                             let attackingNotes = channelIDAttackingNoteMap.get(channelID);
                             if (attackingNotes.length >= 1) {
                                 const channelData = channelInfoMap.get(channelID);
                                 let channelInfo : ChannelInfo;
                                 let instrumentData : InstrumentData;
-                                let art1Info       : Art1Info;
-                                let lart           : DLS.LartChunk;
                                 if (channelData) {
-                                    [channelInfo, instrumentData, art1Info, lart] = channelInfoMap.get(channelID);
+                                    [channelInfo, instrumentData] = channelInfoMap.get(channelID);
                                 }
                                 attackingNotes.forEach((attackingNoteData, arrayIndex) => {
                                     if (!channelData) return;
                                     if (!attackingNoteData) return;
-                                    const [attackedOffset, noteInfo, sampleOffsetSpeedGain, lastSampleOffset] = attackingNoteData;
+                                    const [noteInfo, sampleOffsetSpeedGain, lastSampleOffset] = attackingNoteData;
+                                    const attackedOffset = noteInfo.offset;
                                     const noteID = noteInfo.noteID;
                                     const position = offset - attackedOffset;
                                     const positionFromReleased = offset - noteInfo.endOffset;
@@ -744,10 +780,14 @@ export namespace Synthesizer {
                                         attackingNotes[arrayIndex] = null;
                                         return;
                                     }
-                                    if (!lart && rgn.lart) {
+                                    let art1Info : Art1Info;
+                                    if (instrumentData.insChunk.lart) {
+                                        art1Info = getArt1InfoFromLarts(instrumentData.insChunk.lart);
+                                    }
+                                    if (!instrumentData.insChunk.lart && rgn.lart) {
                                         // ins直属のlartが存在しない -> regionごとのlartのほうを取得(with cache)
                                         art1Info = getArt1InfoFromLarts(rgn.lart);
-                                    } else if (!lart && !rgn.lart) {
+                                    } else if (!instrumentData.insChunk.lart && !rgn.lart) {
                                         // TODO: 一応このケースも想定する必要あり(gm.dlsにはない)
                                         console.error("no ins lart nor rgn lart", channelInfo.instrumentID, rgn);
                                         return;
@@ -875,7 +915,8 @@ export namespace Synthesizer {
                                         }
                                         // サンプル側の取得するべきオフセットを取得(ピッチによる変動を考慮済み)
                                         let sampleOffset = Math.max(0, (lastSampleOffset + sampleOffsetDefaultSpeed * freqRate * nextSampleOffsetSpeedGain));
-                                        channelIDAttackingNoteMap.get(channelID)[arrayIndex] = [attackedOffset, noteInfo, nextSampleOffsetSpeedGain, sampleOffset];
+                                        // speedとOffset更新
+                                        channelIDAttackingNoteMap.get(channelID)[arrayIndex] = [noteInfo, nextSampleOffsetSpeedGain, sampleOffset];
                                         
                                         // サンプルwaveのループ部分
                                         if (waveLooping && sampleOffset >= (waveLoopStart + waveLoopLength)) {
@@ -1006,15 +1047,6 @@ export namespace Synthesizer {
                                         }
                                         waveDataR[offset] += sampleWaveDataR;
                                         waveDataL[offset] += sampleWaveDataL;
-                                        channelWaveDatas.get(channelID)[0][offset] += sampleWaveDataR;
-                                        channelWaveDatas.get(channelID)[1][offset] += sampleWaveDataL;
-                                        // console.log(offset, attackedOffset, noteInfo, positionDX, art1Info, wsmp, position, sampleOffset, freqRate, sampleWaveData, eg1Velocity, waveLoopLength, waveLoopStart, waveInfo.wave.pcmData.length);
-                                        if (sec >= 1 && eg1Attenuation + velocityAttenuation + wsmpAttenuation + lfoAttenuation + volumeAttenuation + expressionAttenuation >= 96) {
-                                            // なり始めてから時間がそれなりに経ち音量が下がりきってる -> 配列から除去(計算の対象外とする)
-                                            attackingNotes[arrayIndex] = null;
-                                        }
-                                        waveDataR[offset] += sampleWaveDataR;
-                                        waveDataL[offset] += sampleWaveDataL;
                                         waveDataWithEffectR[offset] += sampleWaveDataR;
                                         waveDataWithEffectL[offset] += sampleWaveDataL;
 
@@ -1056,6 +1088,35 @@ export namespace Synthesizer {
                                 }
                             }
                         });
+
+                        if (tempLoopStart >= 0) {
+                            loopStartOffset = loopAdjustOffset = tempLoopStart;
+                            if (loopAdjusting) {
+                                channelIDs.forEach((channelID) => {
+                                    // 現在再生中のNoteを記録し、 その音が消えるまでループ位置ををずらす
+                                    channelIDAttackingNoteMap.get(channelID).forEach(attackingNoteData => {
+                                        loopAnnoyingNoteMap.get(channelID).push(attackingNoteData[0]);
+                                    });
+                                    // 現在のチャンネル情報を末尾に追加
+                                    const currentChannelInfo = channelInfoMap.get(channelID)[0];
+                                    offsetChannelInfoMap.get(channelID).set(Math.ceil(maxOffset)-1, currentChannelInfo);
+                                });
+                                console.log("adjusting loop", loopStartOffset, loopAnnoyingNoteMap);
+                            }
+                        }
+                        if (loopAdjusting && loopStartOffset >= 0 && loopAdjustOffset === loopStartOffset) {
+                            let num = 0;
+                            channelIDs.forEach((channelID) => {
+                                const attackingNotes = channelIDAttackingNoteMap.get(channelID);
+                                const annoyingNotes = loopAnnoyingNoteMap.get(channelID);
+                                loopAnnoyingNoteMap.set(channelID, annoyingNotes.filter(note => attackingNotes.findIndex((data) => data[0] === note) >= 0));
+                                num += loopAnnoyingNoteMap.get(channelID).length;
+                            });
+                            if (num === 0) {
+                                loopAdjustOffset = offset;
+                                console.log('adjusted offset', offset, loopStartOffset);
+                            }
+                        }
 
                         // 此処から先はエフェクト処理
                         if (withEffect) {
@@ -1112,11 +1173,20 @@ export namespace Synthesizer {
                         }
                     }
                     // NOTE : かなり雑なループなため, バグるかも
-                    if (endOffset < maxOffset) {
+                    if (endOffset < Math.ceil(maxOffset)) {
                         setTimeout(() => {
-                            processPartialMakeWaveSegment2(endOffset, endOffset+(endOffset-startOffset));
+                            processPartialMakeWaveSegment2(endOffset,Math.min(endOffset+(endOffset-startOffset), Math.ceil(maxOffset)))
                         }, 10);
                     } else {
+                        if (loopAdjusting && endOffset === Math.ceil(maxOffset) && loopAdjustOffset >= 0) {
+                            if (loopLength < 0) {
+                                loopLength = Math.ceil(maxOffset) - loopStartOffset;
+                            }
+                            setTimeout(() => {
+                                processPartialMakeWaveSegment2(Math.ceil(maxOffset), Math.ceil(maxOffset) + loopAdjustOffset-loopStartOffset);
+                            }, 10);
+                            return;
+                        }
                         console.log("processPartialMakeWaveSegment done!");
                         done();
                     }
@@ -1132,7 +1202,7 @@ export namespace Synthesizer {
                 const correctRate = Math.min(32767 / waveDataMaxMin[0], -32768 / waveDataMaxMin[1]);
                 //console.log(waveDataRMax, waveDataRMin, correctRate);
                 if (correctRate < 1) {
-                    for (let offset = 0; offset < maxOffset; offset++) {
+                    for (let offset = 0; offset < maxOffset+(loopAdjusting?(loopAdjustOffset-loopStartOffset):0); offset++) {
                         waveDataR[offset] = Math.round(waveDataR[offset] *  correctRate * 0.99);
                         waveDataL[offset] = Math.round(waveDataL[offset] *  correctRate * 0.99);
                         waveDataWithEffectR[offset] = Math.round(waveDataWithEffectR[offset] *  correctRate * 0.99);
@@ -1273,17 +1343,10 @@ export namespace Synthesizer {
                 result.channelToInstrument = new Map(Array.from(channelIDs).map(channelID => [channelID, channelInfoMap.get(channelID)?.[1]?.insChunk]));
 
                 // ループ設定
-                channelIDs.forEach(channelID => {
-                    const info = channelInfoMap.get(channelID);
-                    if (info[0].loopStartTick >= 0) {
-                        result.loopStartOffset = Math.round(tickToOffset.get(info[0].loopStartTick));
-                        if (info[0].loopLengthTick >= 0) {
-                            result.loopLength = Math.round(tickToOffset.get(info[0].loopLengthTick));
-                        } else {
-                            result.loopLength = Math.round(maxOffset - result.loopStartOffset);
-                        }
-                    }
-                });
+                if (loopStartOffset >= 0) {
+                    result.loopStartOffset = loopAdjusting ? loopAdjustOffset : loopStartOffset;
+                    result.loopLength = loopLength;
+                }
 
                 done(result);
             });


### PR DESCRIPTION
タイトルの通り
RPGツクールXP等のループ設定の入ったmidをoggに変換してRPGツクールMV等で確認するとループ直後に不自然な音が混ざるケースがあった。
ループ先の手前にノートが存在してその余韻が残っていることに起因してたので「それらの余韻がなくなるまでループの位置を先に延ばすことによってループを自然にした」というのが今回の内容

「Adjust Loop offset」にチェックを入れるとこれが行われ、 チェックがないときは今まで通り。

ループずらしに当たり、 ループ先の一部をループ元に持っていくという対応を行っているため、 ループなしで再生させると最後にすごく中途半端な終わり方をするのでチェックを入れる場合はループさせる前提で使用してください。 
当然ですがそもそもMIDIにループ記号が存在してない場合はチェックを入れても今までと変わらないwav, oggが生成されます